### PR TITLE
Add support for node packages

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -67,7 +67,6 @@ var applyCmd = &cobra.Command{
 }
 
 func apply(cmd *cobra.Command, opts options.ApplyOptions) error {
-	//fnDir, _ := functions.FunctionDirFromPath(opts.FilePath)
 	abs, err := functions.AbsPath(opts.FilePath)
 	if err != nil {
 		cmd.SilenceUsage = true

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -4,9 +4,9 @@
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *  
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -18,25 +18,25 @@ package cmd
 
 import (
 	"fmt"
-
-	"github.com/spf13/cobra"
-	"github.com/projectriff/riff-cli/pkg/kubectl"
-	"github.com/projectriff/riff-cli/pkg/ioutils"
 	"os"
-	"github.com/projectriff/riff-cli/pkg/options"
-	"github.com/projectriff/riff-cli/cmd/utils"
-	"github.com/projectriff/riff-cli/cmd/opts"
-	"github.com/projectriff/riff-cli/pkg/functions"
-	"github.com/projectriff/riff-cli/pkg/osutils"
 	"strings"
+
+	"github.com/projectriff/riff-cli/cmd/opts"
+	"github.com/projectriff/riff-cli/cmd/utils"
+	"github.com/projectriff/riff-cli/pkg/functions"
+	"github.com/projectriff/riff-cli/pkg/ioutils"
+	"github.com/projectriff/riff-cli/pkg/kubectl"
+	"github.com/projectriff/riff-cli/pkg/options"
+	"github.com/projectriff/riff-cli/pkg/osutils"
+	"github.com/spf13/cobra"
 )
 
 // applyCmd represents the apply command
 var applyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Apply function resource definitions",
-	Long: `Apply the resource definition[s] included in the path. A resource will be created if it doesn't exist yet.`,
-  Example: `  riff apply -f some/function/path
+	Long:  `Apply the resource definition[s] included in the path. A resource will be created if it doesn't exist yet.`,
+	Example: `  riff apply -f some/function/path
   riff apply -f some/function/path/some.yaml`,
 
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -68,22 +68,28 @@ var applyCmd = &cobra.Command{
 
 func apply(cmd *cobra.Command, opts options.ApplyOptions) error {
 	//fnDir, _ := functions.FunctionDirFromPath(opts.FilePath)
-	abs,err := functions.AbsPath(opts.FilePath)
+	abs, err := functions.AbsPath(opts.FilePath)
 	if err != nil {
 		cmd.SilenceUsage = true
 		return err
 	}
 
-	var cmdArgs []string
+	cmdArgs := []string{"apply", "--namespace", opts.Namespace}
 	var message string
 
 	if osutils.IsDirectory(abs) {
 		message = fmt.Sprintf("Applying resources in %v\n\n", opts.FilePath)
+		resourceDefinitionPaths, err := osutils.FindRiffResourceDefinitionPaths(abs)
+		if err != nil {
+			return err
+		}
+		for _, resourceDefinitionPath := range resourceDefinitionPaths {
+			cmdArgs = append(cmdArgs, "-f", resourceDefinitionPath)
+		}
 	} else {
 		message = fmt.Sprintf("Applying resource %v\n\n", opts.FilePath)
+		cmdArgs = append(cmdArgs, "-f", abs)
 	}
-	cmdArgs = []string{"apply", "--namespace", opts.Namespace, "-f", abs}
-
 
 	if opts.DryRun {
 		fmt.Printf("\nApply Command: kubectl %s\n\n", strings.Trim(fmt.Sprint(cmdArgs), "[]"))

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -113,19 +113,11 @@ func delete(cmd *cobra.Command, opts options.DeleteOptions) error {
 			cmdArgs = []string{"delete", "--namespace", opts.Namespace, "function", opts.FunctionName}
 		} else {
 			message = fmt.Sprintf("Deleting %v resource\n\n", opts.FilePath)
-			resourceDefinitionPaths, err := osutils.FindRiffResourceDefinitionPaths(abs)
-			if err != nil {
-				return err
-			}
-			cmdArgs = []string{"delete", "--namespace", opts.Namespace}
-			for _, resourceDefinitionPath := range resourceDefinitionPaths {
-				cmdArgs = append(cmdArgs, "-f", resourceDefinitionPath)
-			}
+			cmdArgs = []string{"delete", "--namespace", opts.Namespace, "-f", opts.FilePath}
 		}
 	}
 
 	if opts.DryRun {
-		//args := []string{"delete", "-f", abs}
 		fmt.Printf("\nDelete Command: kubectl %s\n\n", strings.Trim(fmt.Sprint(cmdArgs), "[]"))
 	} else {
 		fmt.Print(message)

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -4,9 +4,9 @@
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *  
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,25 +19,26 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-	"github.com/projectriff/riff-cli/pkg/functions"
-	"github.com/projectriff/riff-cli/pkg/kubectl"
-	"github.com/projectriff/riff-cli/pkg/osutils"
-	"path/filepath"
-	"github.com/projectriff/riff-cli/cmd/utils"
-	"github.com/projectriff/riff-cli/pkg/options"
-	"github.com/projectriff/riff-cli/pkg/ioutils"
 	"os"
+	"path/filepath"
 	"strings"
+
+	"github.com/projectriff/riff-cli/cmd/utils"
+	"github.com/projectriff/riff-cli/pkg/functions"
+	"github.com/projectriff/riff-cli/pkg/ioutils"
+	"github.com/projectriff/riff-cli/pkg/kubectl"
+	"github.com/projectriff/riff-cli/pkg/options"
+	"github.com/projectriff/riff-cli/pkg/osutils"
+	"github.com/spf13/cobra"
 )
 
 var DeleteAllOptions options.DeleteAllOptions
 
 // deleteCmd represents the delete command
-var deleteCmd = &cobra.Command {
+var deleteCmd = &cobra.Command{
 	Use:   "delete",
 	Short: "Delete function resources",
-	Long: `Delete the resource[s] for the function or path specified.`,
+	Long:  `Delete the resource[s] for the function or path specified.`,
 	Example: `  riff delete -n square
     or
   riff delete -f function/square`,
@@ -82,7 +83,7 @@ func delete(cmd *cobra.Command, opts options.DeleteOptions) error {
 		}
 	}
 
-	abs,err := functions.AbsPath(opts.FilePath)
+	abs, err := functions.AbsPath(opts.FilePath)
 	if err != nil {
 		cmd.SilenceUsage = true
 		return err
@@ -98,14 +99,28 @@ func delete(cmd *cobra.Command, opts options.DeleteOptions) error {
 			optionPath = filepath.Dir(optionPath)
 		}
 		message = fmt.Sprintf("Deleting %v resources\n\n", optionPath)
-		cmdArgs = []string{"delete", "--namespace", opts.Namespace, "-f", abs}
+		resourceDefinitionPaths, err := osutils.FindRiffResourceDefinitionPaths(abs)
+		if err != nil {
+			return err
+		}
+		cmdArgs = []string{"delete", "--namespace", opts.Namespace}
+		for _, resourceDefinitionPath := range resourceDefinitionPaths {
+			cmdArgs = append(cmdArgs, "-f", resourceDefinitionPath)
+		}
 	} else {
 		if osutils.IsDirectory(abs) {
 			message = fmt.Sprintf("Deleting %v function\n\n", opts.FunctionName)
 			cmdArgs = []string{"delete", "--namespace", opts.Namespace, "function", opts.FunctionName}
 		} else {
 			message = fmt.Sprintf("Deleting %v resource\n\n", opts.FilePath)
-			cmdArgs = []string{"delete", "--namespace", opts.Namespace, "-f", abs}
+			resourceDefinitionPaths, err := osutils.FindRiffResourceDefinitionPaths(abs)
+			if err != nil {
+				return err
+			}
+			cmdArgs = []string{"delete", "--namespace", opts.Namespace}
+			for _, resourceDefinitionPath := range resourceDefinitionPaths {
+				cmdArgs = append(cmdArgs, "-f", resourceDefinitionPath)
+			}
 		}
 	}
 

--- a/pkg/initializers/core/dockerfile_generator.go
+++ b/pkg/initializers/core/dockerfile_generator.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"text/template"
 )
+
 type DockerFileTokens struct {
 	Artifact     string
 	ArtifactBase string
@@ -28,6 +29,14 @@ type DockerFileTokens struct {
 }
 
 func GenerateFunctionDockerFileContents(tmpl string, name string, tokens interface{}) (string, error) {
+	return generateContents(tmpl, name, tokens)
+}
+
+func GenerateFunctionDockerIgnoreContents(tmpl string, name string, tokens interface{}) (string, error) {
+	return generateContents(tmpl, name, tokens)
+}
+
+func generateContents(tmpl string, name string, tokens interface{}) (string, error) {
 	t, err := template.New(name).Parse(tmpl)
 	if err != nil {
 		return "", err

--- a/pkg/initializers/initializers.go
+++ b/pkg/initializers/initializers.go
@@ -4,9 +4,9 @@
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *  
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,19 +17,19 @@
 package initializers
 
 import (
-	"path/filepath"
-	"fmt"
 	"errors"
+	"fmt"
+	"path/filepath"
 
-	"github.com/projectriff/riff-cli/pkg/options"
 	"github.com/projectriff/riff-cli/pkg/initializers/java"
-	"github.com/projectriff/riff-cli/pkg/initializers/python"
 	"github.com/projectriff/riff-cli/pkg/initializers/node"
+	"github.com/projectriff/riff-cli/pkg/initializers/python"
 	"github.com/projectriff/riff-cli/pkg/initializers/shell"
 	"github.com/projectriff/riff-cli/pkg/initializers/utils"
+	"github.com/projectriff/riff-cli/pkg/options"
 )
 
-var supportedExtensions = []string{"js", "jar", "py", "sh"}
+var supportedExtensions = []string{"js", "json", "jar", "py", "sh"}
 
 type Initializer struct {
 	Initialize func(options.InitOptions) error
@@ -37,8 +37,9 @@ type Initializer struct {
 
 var languageForFileExtension = map[string]string{
 	"sh":   "shell",
-	"jar": "java",
+	"jar":  "java",
 	"js":   "node",
+	"json": "node",
 	"py":   "python",
 }
 
@@ -65,7 +66,7 @@ func Shell() Initializer {
 }
 
 func Initialize(opts options.InitOptions) error {
-	filePath, err := utils.ResolveFunctionFile(opts, "","")
+	filePath, err := utils.ResolveFunctionFile(opts, "", "")
 	if err != nil {
 		return err
 	}
@@ -87,5 +88,3 @@ func Initialize(opts options.InitOptions) error {
 	}
 	return nil
 }
-
-

--- a/pkg/initializers/node/dockerfile_generator.go
+++ b/pkg/initializers/node/dockerfile_generator.go
@@ -17,23 +17,49 @@
 package node
 
 import (
-	"github.com/projectriff/riff-cli/pkg/options"
 	"path/filepath"
+
 	"github.com/projectriff/riff-cli/pkg/initializers/core"
+	"github.com/projectriff/riff-cli/pkg/options"
+	"github.com/projectriff/riff-cli/pkg/osutils"
 )
+
+type NodeDockerFileTokens struct {
+	core.DockerFileTokens
+	PackageJSONExists bool
+}
 
 var nodeFunctionDockerfileTemplate = `
 FROM projectriff/node-function-invoker:{{.RiffVersion}}
+{{ if .PackageJSONExists -}}
+ENV FUNCTION_URI /functions/
+COPY . ${FUNCTION_URI}
+RUN (cd ${FUNCTION_URI} && npm install --production)
+{{- else -}}
 ENV FUNCTION_URI /functions/{{.Artifact}}
 ADD {{.ArtifactBase}} ${FUNCTION_URI}
+{{- end }}
 `
 
+// TODO create .dockerignore file
+var nodeFunctionDockerIgnoreTemplate = `
+{{ if .PackageJSONExists -}}
+node_modules
+{{- end }}
+`
 
 func generateNodeFunctionDockerFile(opts options.InitOptions) (string, error) {
-	dockerFileTokens := core.DockerFileTokens{
-		Artifact:     opts.Artifact,
-		ArtifactBase: filepath.Base(opts.Artifact),
-		RiffVersion:  opts.RiffVersion,
-	}
+	dockerFileTokens := NodeDockerFileTokens{}
+	dockerFileTokens.Artifact = opts.Artifact
+	dockerFileTokens.ArtifactBase = filepath.Base(opts.Artifact)
+	dockerFileTokens.RiffVersion = opts.RiffVersion
+	dockerFileTokens.PackageJSONExists = packageJSONExists(opts.FilePath)
 	return core.GenerateFunctionDockerFileContents(nodeFunctionDockerfileTemplate, "docker-node", dockerFileTokens)
+}
+
+func packageJSONExists(filePath string) bool {
+	if !osutils.IsDirectory(filePath) {
+		filePath = filepath.Dir(filePath)
+	}
+	return osutils.FileExists(filepath.Join(filePath, "package.json"))
 }

--- a/pkg/initializers/node/dockerfile_generator.go
+++ b/pkg/initializers/node/dockerfile_generator.go
@@ -41,20 +41,29 @@ ADD {{.ArtifactBase}} ${FUNCTION_URI}
 {{- end }}
 `
 
-// TODO create .dockerignore file
 var nodeFunctionDockerIgnoreTemplate = `
-{{ if .PackageJSONExists -}}
-node_modules
-{{- end }}
-`
+ {{ if .PackageJSONExists -}}
+ node_modules
+ {{- end }}
+ `
 
 func generateNodeFunctionDockerFile(opts options.InitOptions) (string, error) {
+	dockerFileTokens := generateDockerFileTokens(opts)
+	return core.GenerateFunctionDockerFileContents(nodeFunctionDockerfileTemplate, "docker-node", dockerFileTokens)
+}
+
+func generateNodeFunctionDockerIgnore(opts options.InitOptions) (string, error) {
+	dockerFileTokens := generateDockerFileTokens(opts)
+	return core.GenerateFunctionDockerIgnoreContents(nodeFunctionDockerIgnoreTemplate, "docker-node", dockerFileTokens)
+}
+
+func generateDockerFileTokens(opts options.InitOptions) NodeDockerFileTokens {
 	dockerFileTokens := NodeDockerFileTokens{}
 	dockerFileTokens.Artifact = opts.Artifact
 	dockerFileTokens.ArtifactBase = filepath.Base(opts.Artifact)
 	dockerFileTokens.RiffVersion = opts.RiffVersion
 	dockerFileTokens.PackageJSONExists = packageJSONExists(opts.FilePath)
-	return core.GenerateFunctionDockerFileContents(nodeFunctionDockerfileTemplate, "docker-node", dockerFileTokens)
+	return dockerFileTokens
 }
 
 func packageJSONExists(filePath string) bool {

--- a/pkg/initializers/node/dockerfile_generator.go
+++ b/pkg/initializers/node/dockerfile_generator.go
@@ -42,10 +42,10 @@ ADD {{.ArtifactBase}} ${FUNCTION_URI}
 `
 
 var nodeFunctionDockerIgnoreTemplate = `
- {{ if .PackageJSONExists -}}
- node_modules
- {{- end }}
- `
+{{ if .PackageJSONExists -}}
+node_modules
+{{- end }}
+`
 
 func generateNodeFunctionDockerFile(opts options.InitOptions) (string, error) {
 	dockerFileTokens := generateDockerFileTokens(opts)

--- a/pkg/initializers/node/dockerfile_generator_test.go
+++ b/pkg/initializers/node/dockerfile_generator_test.go
@@ -17,9 +17,10 @@
 package node
 
 import (
-	"github.com/projectriff/riff-cli/pkg/options"
 	"fmt"
 	"testing"
+
+	"github.com/projectriff/riff-cli/pkg/options"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,12 +30,38 @@ func TestNodeDockerfile(t *testing.T) {
 	opts := options.InitOptions{
 		Artifact:    "square.js",
 		RiffVersion: "0.0.3",
+		FilePath:    "../../../test_data/node/square/square.js",
 		Handler:     "process",
 	}
 
 	docker, err := generateNodeFunctionDockerFile(opts)
 	as.NoError(err)
-	as.Contains(docker, fmt.Sprintf("FROM projectriff/node-function-invoker:%s", opts.RiffVersion))
-	as.Contains(docker, fmt.Sprintf("ENV FUNCTION_URI /functions/%s", opts.Artifact))
-	as.Contains(docker, fmt.Sprintf("ADD %s ${FUNCTION_URI}", opts.Artifact))
+	as.Contains(docker, fmt.Sprintf("FROM projectriff/node-function-invoker:%s\n", opts.RiffVersion))
+	as.Contains(docker, fmt.Sprintf("ENV FUNCTION_URI /functions/%s\n", opts.Artifact))
+	as.Contains(docker, fmt.Sprintf("ADD %s ${FUNCTION_URI}\n", opts.Artifact))
+
+	as.NotContains(docker, "ENV FUNCTION_URI /functions/\n")
+	as.NotContains(docker, "COPY . ${FUNCTION_URI}\n")
+	as.NotContains(docker, "RUN (cd ${FUNCTION_URI} && npm install --production)\n")
+}
+
+func TestNodePackageDockerfile(t *testing.T) {
+	as := assert.New(t)
+
+	opts := options.InitOptions{
+		Artifact:    "square.js",
+		RiffVersion: "0.0.3",
+		FilePath:    "../../../test_data/node/square-package/square.js",
+		Handler:     "process",
+	}
+
+	docker, err := generateNodeFunctionDockerFile(opts)
+	as.NoError(err)
+	as.Contains(docker, fmt.Sprintf("FROM projectriff/node-function-invoker:%s\n", opts.RiffVersion))
+	as.Contains(docker, "ENV FUNCTION_URI /functions/\n")
+	as.Contains(docker, "COPY . ${FUNCTION_URI}\n")
+	as.Contains(docker, "RUN (cd ${FUNCTION_URI} && npm install --production)\n")
+
+	as.NotContains(docker, fmt.Sprintf("ENV FUNCTION_URI /functions/%s\n", opts.Artifact))
+	as.NotContains(docker, fmt.Sprintf("ADD %s ${FUNCTION_URI}\n", opts.Artifact))
 }

--- a/pkg/initializers/node/initializer.go
+++ b/pkg/initializers/node/initializer.go
@@ -17,10 +17,11 @@
 package node
 
 import (
-	"github.com/projectriff/riff-cli/pkg/options"
-	"github.com/projectriff/riff-cli/pkg/initializers/core"
 	"path/filepath"
+
+	"github.com/projectriff/riff-cli/pkg/initializers/core"
 	"github.com/projectriff/riff-cli/pkg/initializers/utils"
+	"github.com/projectriff/riff-cli/pkg/options"
 )
 
 const (
@@ -38,8 +39,9 @@ func Initialize(opts options.InitOptions) error {
 	workdir := filepath.Dir(functionfile)
 
 	generator := core.ArtifactsGenerator{
-		GenerateFunction:   core.DefaultGenerateFunction,
-		GenerateDockerFile: generateNodeFunctionDockerFile,
+		GenerateFunction:     core.DefaultGenerateFunction,
+		GenerateDockerFile:   generateNodeFunctionDockerFile,
+		GenerateDockerIgnore: generateNodeFunctionDockerIgnore,
 	}
 
 	return core.GenerateFunctionArtfacts(generator, workdir, opts)

--- a/pkg/initializers/utils/function_file.go
+++ b/pkg/initializers/utils/function_file.go
@@ -17,19 +17,21 @@
 package utils
 
 import (
-	"github.com/projectriff/riff-cli/pkg/options"
-	"path/filepath"
-	"github.com/projectriff/riff-cli/pkg/osutils"
-	"fmt"
 	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/projectriff/riff-cli/pkg/options"
+	"github.com/projectriff/riff-cli/pkg/osutils"
 )
 
-var supportedExtensions = []string{"js", "java", "py", "sh"}
+var supportedExtensions = []string{"js", "json", "java", "py", "sh"}
 
 var languageForFileExtensions = map[string]string{
 	"sh":   "shell",
-	"jar": "java",
+	"jar":  "java",
 	"js":   "node",
+	"json": "node",
 	"py":   "python",
 }
 
@@ -81,7 +83,7 @@ func searchForFunctionResource(dir string, name string) (string, error) {
 	}
 
 	foundFile := ""
-	for _, f := range (files) {
+	for _, f := range files {
 		if b := filepath.Base(f); b[0:len(b)-len(filepath.Ext(f))] == name {
 			for _, e := range supportedExtensions {
 				if filepath.Ext(f) == "."+e {

--- a/pkg/initializers/utils/resolve_opts.go
+++ b/pkg/initializers/utils/resolve_opts.go
@@ -17,8 +17,8 @@
 package utils
 
 import (
-
 	"path/filepath"
+
 	"github.com/projectriff/riff-cli/pkg/functions"
 	"github.com/projectriff/riff-cli/pkg/options"
 )

--- a/pkg/osutils/osutils.go
+++ b/pkg/osutils/osutils.go
@@ -4,9 +4,9 @@
  *   Licensed under the Apache License, Version 2.0 (the "License");
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
- *  
+ *
  *        http://www.apache.org/licenses/LICENSE-2.0
- *  
+ *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,
  *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,16 +17,17 @@
 package osutils
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"os"
-	"path/filepath"
+	"os/exec"
 	"os/user"
+	"path/filepath"
 	"strings"
 	"time"
-	"bytes"
+
 	"github.com/projectriff/riff-cli/pkg/ioutils"
-	"fmt"
-	"context"
-	"os/exec"
 )
 
 func GetCWD() string {
@@ -49,7 +50,6 @@ func GetCurrentUsername() string {
 	return user.Username
 }
 
-
 func FileExists(path string) bool {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
@@ -57,6 +57,18 @@ func FileExists(path string) bool {
 		}
 	}
 	return true
+}
+
+func FindRiffResourceDefinitionPaths(path string) ([]string, error) {
+	functions, err := filepath.Glob(filepath.Join(path, "*-function.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	topics, err := filepath.Glob(filepath.Join(path, "*-topics.yaml"))
+	if err != nil {
+		return nil, err
+	}
+	return append(functions, topics...), nil
 }
 
 func IsDirectory(path string) bool {
@@ -72,10 +84,10 @@ func Path(filename string) string {
 	if os.PathSeparator == '/' {
 		return path
 	}
-	return filepath.Join(strings.Split(path,"/")...)
+	return filepath.Join(strings.Split(path, "/")...)
 }
 
-func Exec(cmdName string, cmdArgs [] string, timeout time.Duration) ([]byte, error) {
+func Exec(cmdName string, cmdArgs []string, timeout time.Duration) ([]byte, error) {
 	// Create a new context and add a timeout to it
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel() // The cancel should be deferred so resources are cleaned up

--- a/test_data/node/square-package/package.json
+++ b/test_data/node/square-package/package.json
@@ -1,0 +1,4 @@
+{
+    "dependencies": {},
+    "main": "square.js"
+}

--- a/test_data/node/square-package/square.js
+++ b/test_data/node/square-package/square.js
@@ -1,0 +1,1 @@
+module.exports = x => x ** 2;

--- a/test_data/node/square/square.js
+++ b/test_data/node/square/square.js
@@ -1,0 +1,1 @@
+module.exports = x => x ** 2;


### PR DESCRIPTION
A node package is distinguished from a node module by a package.json
file. A package can contain one or more modules. The package.json file
provides a wealth of metadata including the dependencies to be
installed, the main entry module into the package, custom scripts, and
more.

When a package.json file is present these key changes should occur:
1. all files in the directory are copied into the container
2. production dependencies are installed via npm in the docker daemon
3. the entry point should be defined by the package, and the invoker
   should require the directory instead of a specific module

The package.json file can also provide a conveient hook to apply source
transformations via a postinstall script. For example, compiling
TypeScript, or ES.next via Babel.

Closes projectriff/node-function-invoker#19